### PR TITLE
Add new visualization mode to ERD

### DIFF
--- a/app/assets/stylesheets/erd/erd.css.scss
+++ b/app/assets/stylesheets/erd/erd.css.scss
@@ -536,10 +536,18 @@ li {
   display: none;
 }
 
+#open_visualization_dialog {
+  top: 70px;
+}
+
 #open_create_model_dialog {
+  top: 120px;
+}
+
+.sliding-buttons {
   position: fixed;
   right: 15px;
-  top: 70px;
+  top: 120px;
   background: rgba(0, 0, 0, .6);
   padding: 12px 20px;
   color: $white;
@@ -548,6 +556,7 @@ li {
   &:hover {
     background: rgba(0, 0, 0, .8)
   }
+  z-index: 5;
 }
 
 #create_model_form {
@@ -586,4 +595,27 @@ li {
   width: 160px;
   padding: 2px 10px;
   text-decoration: none;
+}
+
+#erd_box.edit-mode {
+  .add_column_box {
+    display: none;
+  }
+
+  a.close {
+    display: none;
+  }
+
+  #erd {
+    background-color: #fff;
+    background-image: none;
+  }
+}
+
+.columns.hidden {
+  display: none;
+}
+
+.model.hidden {
+  display: none;
 }

--- a/app/controllers/erd/erd_controller.rb
+++ b/app/controllers/erd/erd_controller.rb
@@ -81,7 +81,7 @@ module Erd
       _scale, svg_width, svg_height = plain.scan(/\Agraph ([0-9\.]+) ([0-9\.]+) ([0-9\.]+)$/).first
       # node name x y width height label style shape color fillcolor
       max_model_x, max_model_y = 0, 0
-      models = plain.scan(/^node ([^ ]+) ([0-9\.]+) ([0-9\.]+) ([0-9\.]+) ([0-9\.]+) <\{?(<((?!^\}?>).)*)^\}?> [^ ]+ [^ ]+ [^ ]+ [^ ]+\n/m).map {|node_name, x, y, width, height, label|
+      @models = plain.scan(/^node ([^ ]+) ([0-9\.]+) ([0-9\.]+) ([0-9\.]+) ([0-9\.]+) <\{?(<((?!^\}?>).)*)^\}?> [^ ]+ [^ ]+ [^ ]+ [^ ]+\n/m).map {|node_name, x, y, width, height, label|
         label_doc = Nokogiri::HTML::DocumentFragment.parse(label)
         model_name = node_name.dup
         model_name[0] = model_name[-1] = '' if (model_name.first == '"') && (model_name.last == '"')
@@ -98,7 +98,7 @@ module Erd
       }.compact
       # edge tail head n x1 y1 .. xn yn [label xl yl] style color
       edges = plain.scan(/^edge ([^ ]+)+ ([^ ]+)/).map {|from, to| {:from => from.sub(/^m_/, ''), :to => to.sub(/^m_/, '')}}
-      render_to_string 'erd/erd/erd', :layout => nil, :locals => {:width => [(BigDecimal(svg_width) * 72).round, max_model_x].max, :height => [(BigDecimal(svg_height) * 72).round, max_model_y].max, :models => models, :edges => edges}
+      render_to_string 'erd/erd/erd', :layout => nil, :locals => {:width => [(BigDecimal(svg_width) * 72).round, max_model_x].max, :height => [(BigDecimal(svg_height) * 72).round, max_model_y].max, :models => @models, :edges => edges}
     end
 
     def gsub_file(path, flag, *args, &block)

--- a/app/views/erd/erd/index.html.erb
+++ b/app/views/erd/erd/index.html.erb
@@ -67,7 +67,37 @@
       <%= submit_tag 'run migrations' %>
     <% end %>
   </div>
-  <a href="#" id='open_create_model_dialog'%>Create Model</a>
+  <a href="#" id='open_visualization_dialog' class="sliding-buttons">Visualization</a>
+  <div id='visualization_form'>
+    <form>
+      Edit Mode:
+      <input type="checkbox" id="edit_mode">
+      Show Columns:
+      <input type="checkbox" id="show_columns" checked>
+    </form>
+    <form>
+      <table id="models_visibility_table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Visible?</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>All</strong></td>
+            <td><input type="checkbox" id="toggle_all_models_visibility" checked></td>
+          <% @models.each do |element| %>
+            <tr>
+              <td><%= element[:model] %></td>
+              <td><input type="checkbox" id="toggle_<%= element[:model].downcase %>_visibility" class="toggle_model_visibility" value="<%= element[:model] %>" checked></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </form>
+  </div>
+  <a href="#" id='open_create_model_dialog' class="sliding-buttons">Create Model</a>
   <div id="create_model_form">
     <form>
       Model Name: <input id="new_model_name" name="new_model_name" type="text" /><br>


### PR DESCRIPTION
Edit Mode with no buttons to remove tables or add columns and
a white background with no grid.
Option to hide table columns
Control over visibility per model
Simple show and hide all models

Signed-off-by: João Soares <jsoaresgeral@gmail.com>