### PR TITLE
Replace schema_migrations_table_name as is deprecated

### DIFF
--- a/lib/erd/migrator.rb
+++ b/lib/erd/migrator.rb
@@ -6,7 +6,7 @@ module Erd
   class Migrator
     class << self
       def status
-        migrated_versions = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::Migrator.schema_migrations_table_name}").map {|v| '%.3d' % v}
+        migrated_versions = ActiveRecord::Base.connection.select_values("SELECT version FROM #{ActiveRecord::SchemaMigration.table_name}").map {|v| '%.3d' % v}
         migrations = []
         ActiveRecord::Migrator.migrations_paths.each do |path|
           Dir.foreach(Rails.root.join(path)) do |file|


### PR DESCRIPTION
Simple fix as currently not working since upgrade to rails 5.2

More to follow in upcoming week